### PR TITLE
Rename to registry.opentf.org to registry.opentofu.org

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/opentffoundation/registry-address
+module github.com/opentofu/registry-address
 
 go 1.19
 

--- a/module.go
+++ b/module.go
@@ -34,7 +34,7 @@ type Module struct {
 
 // DefaultModuleRegistryHost is the hostname used for registry-based module
 // source addresses that do not have an explicit hostname.
-const DefaultModuleRegistryHost = svchost.Hostname("registry.opentf.org")
+const DefaultModuleRegistryHost = svchost.Hostname("registry.opentofu.org")
 
 var moduleRegistryNamePattern = regexp.MustCompile("^[0-9A-Za-z](?:[0-9A-Za-z-_]{0,62}[0-9A-Za-z])?$")
 var moduleRegistryTargetSystemPattern = regexp.MustCompile("^[0-9a-z]{1,64}$")

--- a/module_test.go
+++ b/module_test.go
@@ -22,7 +22,7 @@ func TestParseModuleSource_simple(t *testing.T) {
 			input: "hashicorp/subnets/cidr",
 			want: Module{
 				Package: ModulePackage{
-					Host:         svchost.Hostname("registry.opentf.org"),
+					Host:         svchost.Hostname("registry.opentofu.org"),
 					Namespace:    "hashicorp",
 					Name:         "subnets",
 					TargetSystem: "cidr",
@@ -34,7 +34,7 @@ func TestParseModuleSource_simple(t *testing.T) {
 			input: "hashicorp/subnets/cidr//examples/foo",
 			want: Module{
 				Package: ModulePackage{
-					Host:         svchost.Hostname("registry.opentf.org"),
+					Host:         svchost.Hostname("registry.opentofu.org"),
 					Namespace:    "hashicorp",
 					Name:         "subnets",
 					TargetSystem: "cidr",
@@ -104,25 +104,25 @@ func TestParseModuleSource(t *testing.T) {
 	}{
 		"public registry": {
 			input:           `hashicorp/consul/aws`,
-			wantString:      `registry.opentf.org/hashicorp/consul/aws`,
+			wantString:      `registry.opentofu.org/hashicorp/consul/aws`,
 			wantForDisplay:  `hashicorp/consul/aws`,
 			wantForProtocol: `hashicorp/consul/aws`,
 		},
 		"public registry with subdir": {
 			input:           `hashicorp/consul/aws//foo`,
-			wantString:      `registry.opentf.org/hashicorp/consul/aws//foo`,
+			wantString:      `registry.opentofu.org/hashicorp/consul/aws//foo`,
 			wantForDisplay:  `hashicorp/consul/aws//foo`,
 			wantForProtocol: `hashicorp/consul/aws`,
 		},
 		"public registry using explicit hostname": {
-			input:           `registry.opentf.org/hashicorp/consul/aws`,
-			wantString:      `registry.opentf.org/hashicorp/consul/aws`,
+			input:           `registry.opentofu.org/hashicorp/consul/aws`,
+			wantString:      `registry.opentofu.org/hashicorp/consul/aws`,
 			wantForDisplay:  `hashicorp/consul/aws`,
 			wantForProtocol: `hashicorp/consul/aws`,
 		},
 		"public registry with mixed case names": {
 			input:           `HashiCorp/Consul/aws`,
-			wantString:      `registry.opentf.org/HashiCorp/Consul/aws`,
+			wantString:      `registry.opentofu.org/HashiCorp/Consul/aws`,
 			wantForDisplay:  `HashiCorp/Consul/aws`,
 			wantForProtocol: `HashiCorp/Consul/aws`,
 		},
@@ -249,5 +249,5 @@ func ExampleParseModuleSource() {
 		log.Fatal(err)
 	}
 	fmt.Printf("%#v", mAddr)
-	// Output: tfaddr.Module{Package:tfaddr.ModulePackage{Host:svchost.Hostname("registry.opentf.org"), Namespace:"hashicorp", Name:"consul", TargetSystem:"aws"}, Subdir:"modules/consul-cluster"}
+	// Output: tfaddr.Module{Package:tfaddr.ModulePackage{Host:svchost.Hostname("registry.opentofu.org"), Namespace:"hashicorp", Name:"consul", TargetSystem:"aws"}, Subdir:"modules/consul-cluster"}
 }

--- a/provider.go
+++ b/provider.go
@@ -21,7 +21,7 @@ type Provider struct {
 
 // DefaultProviderRegistryHost is the hostname used for provider addresses that do
 // not have an explicit hostname.
-const DefaultProviderRegistryHost = svchost.Hostname("registry.opentf.org")
+const DefaultProviderRegistryHost = svchost.Hostname("registry.opentofu.org")
 
 // BuiltInProviderHost is the pseudo-hostname used for the "built-in" provider
 // namespace. Built-in provider addresses must also have their namespace set

--- a/provider_test.go
+++ b/provider_test.go
@@ -36,10 +36,10 @@ func TestProviderString(t *testing.T) {
 		{
 			Provider{
 				Type:      "test",
-				Hostname:  "registry.opentf.com",
+				Hostname:  "registry.opentofu.com",
 				Namespace: "hashicorp",
 			},
-			"registry.opentf.com/hashicorp/test",
+			"registry.opentofu.com/hashicorp/test",
 		},
 		{
 			Provider{
@@ -106,10 +106,10 @@ func TestProviderDisplay(t *testing.T) {
 		{
 			Provider{
 				Type:      "test",
-				Hostname:  "registry.opentf.com",
+				Hostname:  "registry.opentofu.com",
 				Namespace: "hashicorp",
 			},
-			"registry.opentf.com/hashicorp/test",
+			"registry.opentofu.com/hashicorp/test",
 		},
 		{
 			Provider{
@@ -185,7 +185,7 @@ func TestProviderIsBuiltIn(t *testing.T) {
 		{
 			Provider{
 				Type:      "test",
-				Hostname:  "registry.opentf.com",
+				Hostname:  "registry.opentofu.com",
 				Namespace: "hashicorp",
 			},
 			false,
@@ -224,7 +224,7 @@ func TestProviderIsLegacy(t *testing.T) {
 		{
 			Provider{
 				Type:      "test",
-				Hostname:  "registry.opentf.com",
+				Hostname:  "registry.opentofu.com",
 				Namespace: LegacyProviderNamespace,
 			},
 			false,
@@ -253,7 +253,7 @@ func ExampleParseProviderSource() {
 		log.Fatal(err)
 	}
 	fmt.Printf("%#v", pAddr)
-	// Output: tfaddr.Provider{Type:"aws", Namespace:"hashicorp", Hostname:svchost.Hostname("registry.opentf.org")}
+	// Output: tfaddr.Provider{Type:"aws", Namespace:"hashicorp", Hostname:svchost.Hostname("registry.opentofu.org")}
 }
 
 func TestParseProviderSource(t *testing.T) {
@@ -261,7 +261,7 @@ func TestParseProviderSource(t *testing.T) {
 		Want Provider
 		Err  bool
 	}{
-		"registry.opentf.org/hashicorp/aws": {
+		"registry.opentofu.org/hashicorp/aws": {
 			Provider{
 				Type:      "aws",
 				Namespace: "hashicorp",
@@ -269,7 +269,7 @@ func TestParseProviderSource(t *testing.T) {
 			},
 			false,
 		},
-		"registry.Opentf.org/HashiCorp/AWS": {
+		"registry.opentofu.org/HashiCorp/AWS": {
 			Provider{
 				Type:      "aws",
 				Namespace: "hashicorp",
@@ -419,11 +419,11 @@ func TestParseProviderSource(t *testing.T) {
 		// the longer prefix terraform-provider- to hint for users who might be
 		// accidentally using the git repository name or executable file name
 		// instead of the provider type.
-		"example.com/opentffoundation/terraform-provider-bad": {
+		"example.com/opentofu/terraform-provider-bad": {
 			Provider{},
 			true,
 		},
-		"example.com/opentffoundation/terraform-bad": {
+		"example.com/opentofu/terraform-bad": {
 			Provider{},
 			true,
 		},


### PR DESCRIPTION
Do to the recent name change of the project to OpenToFu, the registry domain needs to change to `registry.opentofu.org`. Part of [the renaming effort](https://github.com/opentofu/opentofu/issues/451) of the project 