### PR TITLE
Allow underscores in provider namespace

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -466,12 +466,50 @@ func ParseProviderPart(given string) (string, error) {
 		return "", fmt.Errorf("cannot use multiple consecutive dashes")
 	}
 
-	result, err := idna.Lookup.ToUnicode(given)
-	if err != nil {
-		return "", fmt.Errorf("must contain only letters, digits, and dashes, and may not use leading or trailing dashes")
+	// Similarly, reject consecutive underscores
+	if strings.Contains(given, "__") {
+		return "", fmt.Errorf("cannot use multiple consecutive underscores")
 	}
 
-	return result, nil
+	// Check for leading or trailing underscores
+	if strings.HasPrefix(given, "_") || strings.HasSuffix(given, "_") {
+		return "", fmt.Errorf("underscores may not be used as a prefix or suffix")
+	}
+
+	// Process the string in segments split by underscores, since IDNA doesn't allow underscores.
+	// Each segment between underscores is validated through IDNA, while underscores are preserved.
+	var segment strings.Builder
+	var result strings.Builder
+
+	flush := func() error {
+		if segment.Len() == 0 {
+			return nil
+		}
+		normalized, err := idna.Lookup.ToUnicode(segment.String())
+		if err != nil {
+			return fmt.Errorf("must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores")
+		}
+		result.WriteString(normalized)
+		segment.Reset()
+		return nil
+	}
+
+	for _, r := range given {
+		if r == '_' {
+			if err := flush(); err != nil {
+				return "", err
+			}
+			result.WriteRune('_')
+		} else {
+			segment.WriteRune(r)
+		}
+	}
+
+	if err := flush(); err != nil {
+		return "", err
+	}
+
+	return result.String(), nil
 }
 
 // MustParseProviderPart is a wrapper around ParseProviderPart that panics if

--- a/provider_test.go
+++ b/provider_test.go
@@ -534,11 +534,11 @@ func TestParseProviderPart(t *testing.T) {
 			`test_123`,
 			``,
 		},
-		`_abc123`: {
+		`_abc12`: {
 			``,
 			`underscores may not be used as a prefix or suffix`,
 		},
-		`abc123_`: {
+		`abc12_`: {
 			``,
 			`underscores may not be used as a prefix or suffix`,
 		},

--- a/provider_test.go
+++ b/provider_test.go
@@ -512,11 +512,39 @@ func TestParseProviderPart(t *testing.T) {
 		},
 		`-abc123`: {
 			``,
-			`must contain only letters, digits, and dashes, and may not use leading or trailing dashes`,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
 		},
 		`abc123-`: {
 			``,
-			`must contain only letters, digits, and dashes, and may not use leading or trailing dashes`,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo_bar`: {
+			`foo_bar`,
+			``,
+		},
+		`foo_baar`: {
+			`foo_baar`,
+			``,
+		},
+		`Foo_Bar`: {
+			`foo_bar`,
+			``,
+		},
+		`test_123`: {
+			`test_123`,
+			``,
+		},
+		`_abc123`: {
+			``,
+			`underscores may not be used as a prefix or suffix`,
+		},
+		`abc123_`: {
+			``,
+			`underscores may not be used as a prefix or suffix`,
+		},
+		`foo__bar`: {
+			``,
+			`cannot use multiple consecutive underscores`,
 		},
 		``: {
 			``,


### PR DESCRIPTION
## Issue                                                                                                        
                                                                                                                  
  When running `tofu init` with a provider source that contains underscores in the namespace, the initialization  
  fails with a validation error.                                                                                  
                                                                                                                  
  ### Error                                                                                                       
`  tofu init`
                                                                                                                  
  ```
Initializing the backend...
  Initializing modules...                                                                                         
  ╷               
  │ Error: Invalid provider namespace                                                                             
  │                                                                                                               
  │   on main.tf line 8, in terraform:                                                                            
  │    8:       source = "provider.example.io/example_org_id/my-provider"                                         
  │                                                                                                               
  │ Invalid provider namespace "" in source "provider.example.io/example_org_id/my-provider":                     
  │ must contain only letters, digits, and dashes, and may not use leading or trailing dashes                     
                                                 
```                                                                 
  ### Root Cause                                                                                                  
                                                                                                                  
  The `ParseProviderPart` function was validating provider namespaces and names using IDNA (Internationalized     
  Domain Names in Applications), which only accepts letters, digits, and dashes. However, many provider registries
   use auto-generated identifiers that include underscores (e.g., `example_org_id`, `user_workspace_id`).         
                  
  ### Example Provider Sources That Failed                                                                        
   
  ```hcl                                                                                                          
  terraform {     
    required_providers {                                                                                          
      my-provider {                                                                                               
        source = "provider.example.io/example_org_id/my-provider"                                                 
      }                                                                                                           
    }                                                                                                             
  }     
```                                                                                                          
  This issue has also been reported by many users in the Terraform community:                                     
  **https://github.com/hashicorp/terraform/issues/32694**    
                                                                                                             
  Solution
                                                                                                                  
  Modified the validation logic to:                                                                               
  1. Accept underscores in addition to letters, digits, and dashes
  2. Apply the same rules as dashes: no leading/trailing underscores, no consecutive underscores (__)             
  3. Process each segment between underscores through IDNA for Unicode normalization while preserving underscores in their original positions                                                                                     

## PR changes 
This pull request updates the logic for parsing provider part names in `provider.go` to allow underscores with specific restrictions, and adds comprehensive test coverage for these new rules in `provider_test.go`. The changes ensure that underscores are handled safely, preventing problematic patterns like consecutive or leading/trailing underscores.

Validation and normalization improvements:

* Updated `ParseProviderPart` to allow underscores in provider part names, but reject multiple consecutive underscores, and leading or trailing underscores. Each segment between underscores is normalized using IDNA, while underscores themselves are preserved.
* Improved error messages to reflect the new rules, specifying that only letters, digits, dashes, and underscores are allowed, and that leading/trailing dashes or underscores are not permitted.

Test coverage enhancements:

* Added new test cases in `TestParseProviderPart` to verify acceptance of valid names with underscores (e.g., `foo_bar`, `test_123`), correct normalization (e.g., `Foo_Bar` to `foo_bar`), and rejection of invalid patterns (e.g., `_abc123`, `foo__bar`).