### PR TITLE
Allow underscores in provider namespace

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -457,7 +457,7 @@ func ParseProviderPart(given string) (string, error) {
 		return "", fmt.Errorf("dots are not allowed")
 	}
 
-	// We don't allow names containing multiple consecutive dashes, just as
+	// We don't allow names containing multiple consecutive dashes or underscores, just as
 	// a matter of preference: they look weird, confusing, or incorrect.
 	// This also, as a side-effect, prevents the use of the "punycode"
 	// indicator prefix "xn--" that would cause the IDNA library to interpret
@@ -465,10 +465,24 @@ func ParseProviderPart(given string) (string, error) {
 	if strings.Contains(given, "--") {
 		return "", fmt.Errorf("cannot use multiple consecutive dashes")
 	}
+	if strings.Contains(given, "__") {
+		return "", fmt.Errorf("cannot use multiple consecutive underscores")
+	}
 
-	result, err := idna.Lookup.ToUnicode(given)
+	// Similarly, default domain lookup does not allow a dash as a
+	// prefix or suffix, but does allow underscores. We do not.
+	if strings.HasPrefix(given, "_") || strings.HasSuffix(given, "_") {
+		return "", fmt.Errorf("underscores may not be used as a prefix or suffix")
+	}
+
+	unicodeProfile := idna.New(
+		idna.MapForLookup(),
+		idna.BidiRule(),
+		idna.StrictDomainName(false),
+	)
+	result, err := unicodeProfile.ToUnicode(given)
 	if err != nil {
-		return "", fmt.Errorf("must contain only letters, digits, and dashes, and may not use leading or trailing dashes")
+		return "", fmt.Errorf("must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores")
 	}
 
 	return result, nil

--- a/provider.go
+++ b/provider.go
@@ -469,6 +469,9 @@ func ParseProviderPart(given string) (string, error) {
 	if strings.Contains(given, "__") {
 		return "", fmt.Errorf("cannot use multiple consecutive underscores")
 	}
+	if strings.Contains(given, "_-") || strings.Contains(given, "-_") {
+		return "", fmt.Errorf("cannot use consecutive underscores and dashes")
+	}
 
 	// Similarly, default domain lookup does not allow a dash as a
 	// prefix or suffix, but does allow underscores. We do not.

--- a/provider.go
+++ b/provider.go
@@ -7,6 +7,7 @@ package regaddr
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/opentofu/svchost"
 	"golang.org/x/net/idna"
@@ -485,7 +486,29 @@ func ParseProviderPart(given string) (string, error) {
 		return "", fmt.Errorf("must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores")
 	}
 
+	// we're also implementing a slightly more permissive version of the UseSTD3ASCIIRules:
+	// https://www.unicode.org/reports/tr46/#UseSTD3ASCIIRules
+	// If a given code point is ASCII (i.e. ) then it must be
+	// a lowercase letter (a-z), a digit (0-9), or a hyphen-minus (U+002D),
+	// OR a "low line" (U+005F)
+	// We process the result string after it has been checked by the not-as-strict baseline
+
+	for _, r := range result {
+		if r <= unicode.MaxASCII && !validDomainASCII(r) {
+			return "", fmt.Errorf("must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores")
+		}
+	}
+
 	return result, nil
+}
+
+// validDomainASCII returns true if the provided code point is
+// a lowercase letter (a-z) (U+0061...U+007A),
+// a digit (0-9) (U+0030...U+0039),
+// a hyphen-minus ('-') (U+002D),
+// or a "low line" ('_') (U+005F)
+func validDomainASCII(r rune) bool {
+	return (0x61 <= r && r <= 0x7A) || (0x30 <= r && r <= 0x39) || r == 0x2D || r == 0x5F
 }
 
 // MustParseProviderPart is a wrapper around ParseProviderPart that panics if

--- a/provider_test.go
+++ b/provider_test.go
@@ -546,6 +546,51 @@ func TestParseProviderPart(t *testing.T) {
 			``,
 			`cannot use multiple consecutive underscores`,
 		},
+		`foo_-bar`: {
+			``,
+			`cannot use consecutive underscores and dashes`,
+		},
+		`foo-_bar`: {
+			``,
+			`cannot use consecutive underscores and dashes`,
+		},
+		// ASCII punctuation tests
+		`foo|bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo&bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo:bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo~bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo^bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo,bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo'bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo"bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo bar`: {
+			``,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
 		``: {
 			``,
 			`must have at least one character`,

--- a/provider_test.go
+++ b/provider_test.go
@@ -512,11 +512,39 @@ func TestParseProviderPart(t *testing.T) {
 		},
 		`-abc123`: {
 			``,
-			`must contain only letters, digits, and dashes, and may not use leading or trailing dashes`,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
 		},
 		`abc123-`: {
 			``,
-			`must contain only letters, digits, and dashes, and may not use leading or trailing dashes`,
+			`must contain only letters, digits, dashes, and underscores, and may not use leading or trailing dashes or underscores`,
+		},
+		`foo_bar`: {
+			`foo_bar`,
+			``,
+		},
+		`foo_baar`: {
+			`foo_baar`,
+			``,
+		},
+		`Foo_Bar`: {
+			`foo_bar`,
+			``,
+		},
+		`test_123`: {
+			`test_123`,
+			``,
+		},
+		`_abc12`: {
+			``,
+			`underscores may not be used as a prefix or suffix`,
+		},
+		`abc12_`: {
+			``,
+			`underscores may not be used as a prefix or suffix`,
+		},
+		`foo__bar`: {
+			``,
+			`cannot use multiple consecutive underscores`,
 		},
 		``: {
 			``,
@@ -529,7 +557,7 @@ func TestParseProviderPart(t *testing.T) {
 			got, err := ParseProviderPart(given)
 			if test.Error != "" {
 				if err == nil {
-					t.Errorf("unexpected success\ngot:  %s\nwant: %s", err, test.Error)
+					t.Errorf("unexpected success\ngot:  <nil>\nwant: %s", test.Error)
 				} else if got := err.Error(); got != test.Error {
 					t.Errorf("wrong error\ngot:  %s\nwant: %s", got, test.Error)
 				}


### PR DESCRIPTION
Following @apparentlymart idea [in this comment](https://github.com/opentofu/registry-address/pull/8#issuecomment-4207972519). I've also added a couple of checks for prefix/suffix underscores, as well as consecutive underscores.

The tests are entirely written by @nakhthar, who should probably get most of the credit for this PR given the amount of work they put in triage, determining the area to change, etc. @nakhthar is the original author of #8 which this PR is based off of.